### PR TITLE
fix image path error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ function App() {
           <div className="">
           <img
             className="rounded-lg"
-            src="..\public\src\assets\images\image-qr-code.png"
+            src="/image-qr-code.png"
             alt="QR CODE"
           />
           </div>


### PR DESCRIPTION
Public is basically the root path, you don't need to access it like it's a directory 